### PR TITLE
Can't remove relationships on resource save

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -93,16 +93,16 @@ abstract class Resource extends ResourceIdentifier implements ResourceStoreAcces
         $relationships = [];
 
         foreach ($this->to_one_relationships as $name => $relationship) {
-            $encode = $relationship->encodeIdentifier();
-            if ($encode['data'] !== null) {
-                $relationships[$name] = $encode;
+            $encoded = $relationship->encodeIdentifier();
+            if ($encoded['data'] !== null) {
+                $relationships[$name] = $encoded;
             }
         }
 
         foreach ($this->to_many_relationships as $name => $relationship) {
-            $encode = $relationship->encodeIdentifier();
-            if ($encode !== []) {
-                $relationships[$name] = $encode;
+            $encoded = $relationship->encodeIdentifier();
+            if ($encoded !== []) {
+                $relationships[$name] = $encoded;
             }
         }
 

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -93,11 +93,23 @@ abstract class Resource extends ResourceIdentifier implements ResourceStoreAcces
         $relationships = [];
 
         foreach ($this->to_one_relationships as $name => $relationship) {
-            $relationships[$name] = $relationship->encodeIdentifier();
+            $encode = $relationship->encodeIdentifier();
+            if ($encode['data'] !== null) {
+                $relationships[$name] = $encode;
+            }
         }
 
         foreach ($this->to_many_relationships as $name => $relationship) {
-            $relationships[$name] = $relationship->encodeIdentifier();
+            $encode = $relationship->encodeIdentifier();
+            if ($encode !== []) {
+                $relationships[$name] = $encode;
+            }
+        }
+
+        $attributes = [];
+
+        foreach ($this->attributes as $name => $value) {
+            $attributes[$name] = $value;
         }
 
         $data = [
@@ -109,7 +121,7 @@ abstract class Resource extends ResourceIdentifier implements ResourceStoreAcces
         }
 
         $data['data']['type'] = $this->getType();
-        $data['data']['attributes'] = $this->attributes;
+        $data['data']['attributes'] = $attributes;
         $data['data']['relationships'] = $relationships;
 
         return $data;

--- a/src/ToManyRelationship.php
+++ b/src/ToManyRelationship.php
@@ -68,9 +68,9 @@ class ToManyRelationship implements ResourceStoreAccess
     {
         if ($this->resource_collection instanceof ResourceCollection) {
             return $this->resource_collection->encodeIdentifier();
-        } else {
-            return [];
         }
+
+        return [];
     }
 
     // }}}

--- a/src/ToManyRelationship.php
+++ b/src/ToManyRelationship.php
@@ -66,7 +66,11 @@ class ToManyRelationship implements ResourceStoreAccess
 
     public function encodeIdentifier()
     {
-        return $this->resource_collection->encodeIdentifier();
+        if ($this->resource_collection instanceof ResourceCollection) {
+            return $this->resource_collection->encodeIdentifier();
+        } else {
+            return [];
+        }
     }
 
     // }}}

--- a/src/ToOneRelationship.php
+++ b/src/ToOneRelationship.php
@@ -62,7 +62,11 @@ class ToOneRelationship implements ResourceStoreAccess
 
     public function encodeIdentifier()
     {
-        return $this->resource->encodeIdentifier();
+        if ($this->resource instanceof ResourceIdentifier) {
+            return $this->resource->encodeIdentifier();
+        } else {
+            return [ 'data' => null ];
+        }
     }
 
     // }}}

--- a/src/ToOneRelationship.php
+++ b/src/ToOneRelationship.php
@@ -64,9 +64,9 @@ class ToOneRelationship implements ResourceStoreAccess
     {
         if ($this->resource instanceof ResourceIdentifier) {
             return $this->resource->encodeIdentifier();
-        } else {
-            return [ 'data' => null ];
         }
+
+        return [ 'data' => null ];
     }
 
     // }}}


### PR DESCRIPTION
According to the spec:

```
If a relationship is provided in the relationships member of the resource object, its value MUST be a relationship object with a data member. The value of this key represents the linkage the new resource is to have.
```

The JSON API server is not expecting a null value here so don't send it.