### PR TITLE
Fix formatting of resource encoding

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -133,7 +133,7 @@ abstract class Resource extends ResourceIdentifier
 
         foreach ($this->to_many_relationships as $name => $relationship) {
             $encoded = $relationship->encodeIdentifier();
-            if ($encoded !== []) {
+            if ($encoded['data'] !== []) {
                 $relationships[$name] = $encoded;
             }
         }

--- a/src/ResourceCollection.php
+++ b/src/ResourceCollection.php
@@ -112,12 +112,13 @@ class ResourceCollection implements ResourceStoreAccess, \Countable, \Serializab
 
     public function encodeIdentifier()
     {
-        $data = [];
+        $data = [ 'data' => [] ];
 
         // Don't use the object itself to get the iterator.
         // Prevents lazy loading.
         foreach ($this->collection as $resource) {
-            $data[] = $resource->encodeIdentifier();
+            $sub_data = $resource->encodeIdentifier();
+            $data['data'][] = $sub_data['data'];
         }
 
         return $data;


### PR DESCRIPTION
We weren't displaying the correct format of a to many relationship in our output.