### PR TITLE
Code to toggle replacing of to-many relationships

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -120,21 +120,28 @@ abstract class Resource extends ResourceIdentifier
     // }}}
     // {{{ public function encode()
 
-    public function encode()
+    public function encode(array $options = [])
     {
+        $is_to_many_replace_enabled = (
+            !isset($options['to_many_replace_enabled']) ||
+            $options['to_many_replace_enabled']
+        );
+
         $relationships = [];
 
         foreach ($this->to_one_relationships as $name => $relationship) {
-            $encoded = $relationship->encodeIdentifier();
+            $encoded = $relationship->encodeIdentifier($options);
             if ($encoded['data'] !== null) {
                 $relationships[$name] = $encoded;
             }
         }
 
-        foreach ($this->to_many_relationships as $name => $relationship) {
-            $encoded = $relationship->encodeIdentifier();
-            if ($encoded['data'] !== []) {
-                $relationships[$name] = $encoded;
+        if ($is_to_many_replace_enabled) {
+            foreach ($this->to_many_relationships as $name => $relationship) {
+                $encoded = $relationship->encodeIdentifier($options);
+                if ($encoded['data'] !== []) {
+                    $relationships[$name] = $encoded;
+                }
             }
         }
 

--- a/src/ResourceCollection.php
+++ b/src/ResourceCollection.php
@@ -94,14 +94,14 @@ class ResourceCollection implements ResourceStoreAccess, \Countable, \Serializab
     // }}}
     // {{{ public function encode()
 
-    public function encode()
+    public function encode(array $options = [])
     {
         $data = [];
 
         // Don't use the object itself to get the interator.
         // Prevents lazy loading.
         foreach ($this->collection as $resource) {
-            $data[] = $resource->encode();
+            $data[] = $resource->encode($options);
         }
 
         return $data;
@@ -110,14 +110,14 @@ class ResourceCollection implements ResourceStoreAccess, \Countable, \Serializab
     // }}}
     // {{{ public function encodeIdentifier()
 
-    public function encodeIdentifier()
+    public function encodeIdentifier(array $options = [])
     {
         $data = [ 'data' => [] ];
 
         // Don't use the object itself to get the iterator.
         // Prevents lazy loading.
         foreach ($this->collection as $resource) {
-            $sub_data = $resource->encodeIdentifier();
+            $sub_data = $resource->encodeIdentifier($options);
             $data['data'][] = $sub_data['data'];
         }
 

--- a/src/ResourceIdentifier.php
+++ b/src/ResourceIdentifier.php
@@ -56,15 +56,15 @@ class ResourceIdentifier implements ResourceStoreAccess, \Serializable
     // }}}
     // {{{ public function encode()
 
-    public function encode()
+    public function encode(array $options = [])
     {
-        return $this->encodeIndentifier();
+        return $this->encodeIndentifier($options);
     }
 
     // }}}
     // {{{ public function encodeIdentifier()
 
-    public function encodeIdentifier()
+    public function encodeIdentifier(array $options = [])
     {
         return [
             'data' => [

--- a/src/ResourceStore.php
+++ b/src/ResourceStore.php
@@ -229,10 +229,15 @@ class ResourceStore
 
     public function save(Resource $resource)
     {
-        $method = ($resource->getId()) ? 'PATCH' : 'POST';
-        $options = [
-            'is_to_many_replace_enabled' => $this->is_to_many_replace_enabled,
-        ];
+        $method = 'POST';
+        $options = [];
+
+        // Check if we are Updating an existing resource.
+        if (!$resource->getId()) {
+            $method = 'PATCH';
+            $options['is_to_many_replace_enabled'] = $this->is_to_many_replace_enabled;
+        }
+
         $json = $resource->encode($options);
 
         $body = $this->doRequest(

--- a/src/ResourceStore.php
+++ b/src/ResourceStore.php
@@ -233,7 +233,7 @@ class ResourceStore
         $options = [];
 
         // Check if we are Updating an existing resource.
-        if (!$resource->getId()) {
+        if ($resource->isSaved()) {
             $method = 'PATCH';
             $options['is_to_many_replace_enabled'] = $this->is_to_many_replace_enabled;
         }

--- a/src/ResourceStore.php
+++ b/src/ResourceStore.php
@@ -28,7 +28,7 @@ class ResourceStore
 
     protected $resources = [];
 
-    protected $disable_to_many_replace = false;
+    protected $is_to_many_replace_enabled = true;
 
     // }}}
     // {{{ public function __construct()
@@ -235,7 +235,7 @@ class ResourceStore
         if ($resource->getId() != '') {
             $method = 'PATCH';
 
-            if ($this->disable_to_many_replace) {
+            if (!$this->is_to_many_replace_enabled) {
                 $json = $this->removeToManyRelationships($json);
             }
         }
@@ -269,7 +269,7 @@ class ResourceStore
 
     // }}}
     // {{{ public function delete()
-    
+
     public function delete(Resource $resource)
     {
         if ($resource->isSaved()) {
@@ -302,7 +302,7 @@ class ResourceStore
 
     public function enableToManyReplace()
     {
-        $this->disable_to_many_replace = false;
+        $this->is_to_many_replace_enabled = false;
     }
 
     // }}}
@@ -310,7 +310,7 @@ class ResourceStore
 
     public function disableToManyReplace()
     {
-        $this->disable_to_many_replace = true;
+        $this->is_to_many_replace_enabled = false;
     }
 
     // }}}

--- a/src/ResourceStore.php
+++ b/src/ResourceStore.php
@@ -229,16 +229,11 @@ class ResourceStore
 
     public function save(Resource $resource)
     {
-        $method = 'POST';
-        $json = $resource->encode();
-
-        if ($resource->getId() != '') {
-            $method = 'PATCH';
-
-            if (!$this->is_to_many_replace_enabled) {
-                $json = $this->removeToManyRelationships($json);
-            }
-        }
+        $method = ($resource->getId()) ? 'PATCH' : 'POST';
+        $options = [
+            'is_to_many_replace_enabled' => $this->is_to_many_replace_enabled,
+        ];
+        $json = $resource->encode($options);
 
         $body = $this->doRequest(
             $method,

--- a/src/ResourceStore.php
+++ b/src/ResourceStore.php
@@ -438,25 +438,6 @@ class ResourceStore
     }
 
     // }}}
-    // {{{ protected function removeToManyRelationships()
-
-    protected function removeToManyRelationships(array $json)
-    {
-        $to_many_keys = [];
-        foreach ($json['data']['relationships'] as $key => $data) {
-            if (!isset($data['data']['id'])) {
-                $to_many_keys[] = $key;
-            }
-        }
-
-        foreach ($to_many_keys as $to_many_key) {
-            unset($json['data']['relationships'][$to_many_key]);
-        }
-
-        return $json;
-    }
-
-    // }}}
 
     // class methods
     // {{{ public function addClass()

--- a/src/ResourceStore.php
+++ b/src/ResourceStore.php
@@ -238,7 +238,6 @@ class ResourceStore
             $options['is_to_many_replace_enabled'] = $this->is_to_many_replace_enabled;
         }
 
-        $json = $resource->encode($options);
 
         $body = $this->doRequest(
             $method,
@@ -246,7 +245,7 @@ class ResourceStore
                 $resource->getType(),
                 $resource->getId()
             ),
-            ['json' => $json]
+            ['json' => $resource->encode($options)]
         );
 
         if (!isset($body['data'])) {

--- a/src/ResourceStore.php
+++ b/src/ResourceStore.php
@@ -232,7 +232,7 @@ class ResourceStore
         $method = 'POST';
         $options = [];
 
-        // Check if we are Updating an existing resource.
+        // Check if we are updating an existing resource.
         if ($resource->isSaved()) {
             $method = 'PATCH';
             $options['is_to_many_replace_enabled'] = $this->is_to_many_replace_enabled;

--- a/src/ToManyRelationship.php
+++ b/src/ToManyRelationship.php
@@ -68,10 +68,10 @@ class ToManyRelationship implements ResourceStoreAccess
     // }}}
     // {{{ public function encodeIdentifier()
 
-    public function encodeIdentifier()
+    public function encodeIdentifier(array $options = [])
     {
         if ($this->resource_collection instanceof ResourceCollection) {
-            return $this->resource_collection->encodeIdentifier();
+            return $this->resource_collection->encodeIdentifier($options);
         }
 
         return [];

--- a/src/ToOneRelationship.php
+++ b/src/ToOneRelationship.php
@@ -64,10 +64,10 @@ class ToOneRelationship implements ResourceStoreAccess
     // }}}
     // {{{ public function encodeIdentifier()
 
-    public function encodeIdentifier()
+    public function encodeIdentifier(array $options = [])
     {
         if ($this->resource instanceof ResourceIdentifier) {
-            return $this->resource->encodeIdentifier();
+            return $this->resource->encodeIdentifier($options);
         }
 
         return [ 'data' => null ];


### PR DESCRIPTION
Some JSON API servers don't support replacing to-many relationships in an update so add the ability to our datastore to disable sending them with save requests.