### PR TITLE
Only store type for indetifiers.

### DIFF
--- a/src/AbstractResource.php
+++ b/src/AbstractResource.php
@@ -24,14 +24,6 @@ abstract class AbstractResource implements ResourceStoreAccess, \Serializable
     }
 
     // }}}
-    // {{{ public function getType()
-
-    public function getType()
-    {
-        return $this->type;
-    }
-
-    // }}}
     // {{{ public function getId()
 
     public function getId()
@@ -61,6 +53,11 @@ abstract class AbstractResource implements ResourceStoreAccess, \Serializable
             ]
         ];
     }
+
+    // }}}
+    // {{{ abstract public function getType()
+
+    abstract public function getType();
 
     // }}}
     // {{{ abstract public function encode()

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -525,7 +525,6 @@ abstract class Resource extends AbstractResource
     public function serialize()
     {
         return serialize([
-            'type' => $this->getType(),
             'id' => $this->id,
             'attributes' => $this->attributes,
             'attributes_types' => $this->attributes_types,

--- a/src/ResourceIdentifier.php
+++ b/src/ResourceIdentifier.php
@@ -6,6 +6,19 @@ namespace silverorange\JsonApiClient;
 
 class ResourceIdentifier extends AbstractResource
 {
+    // {{{ protected properties
+
+    protected $type = null;
+
+    // }}}
+    // {{{ public function getType()
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    // }}}
     // {{{ public function encode()
 
     public function encode(array $options = [])


### PR DESCRIPTION
Resource objects will hard code which type they are.