### PR TITLE
Allow non-model requests

### DIFF
--- a/src/ResourceStore.php
+++ b/src/ResourceStore.php
@@ -322,6 +322,29 @@ class ResourceStore
     }
 
     // }}}
+    // {{{ public function doNonModelRequest()
+
+    /**
+     * Submits a request against a non-model resource on the server.
+     * No storage is done on the result. The caller is responsible for
+     * processing any data returned.
+     *
+     * @param string $method       the  HTTP method to use.
+     * @param string $endpoint     the endpoint to contact.
+     * @param array  $query_params optional array of extra parameters.
+     *
+     * @return string body
+     */
+    public function doNonModelRequest($method, $endpoint, array $params)
+    {
+        return $this->doRequest(
+            $method,
+            $this->getResourceAddress($endpoint),
+            $params
+        );
+    }
+
+    // }}}
     // {{{ protected function doRequest()
 
     protected function doRequest($method, $url, array $params)


### PR DESCRIPTION
This adds a function to allow clients to submit non-model requests against the resource server without having to reconfigure a second identical http client. 

I did it this way rather than exposing doRequest or the http client to prevent people from accidentally bypassing the storage functions in their model code. 