### PR TITLE
Save JSON-API metadata after querying data

### DIFF
--- a/src/ResourceCollection.php
+++ b/src/ResourceCollection.php
@@ -12,6 +12,7 @@ class ResourceCollection implements ResourceStoreAccess, \Countable, \Serializab
     protected $type = null;
     protected $store = null;
     protected $collection = [];
+    protected $meta = [];
 
     // }}}
     // {{{ public function __construct()
@@ -169,6 +170,22 @@ class ResourceCollection implements ResourceStoreAccess, \Countable, \Serializab
         }
 
         return $is_modified;
+    }
+
+    // }}}
+    // {{{ public function setMeta()
+
+    public function setMeta($meta)
+    {
+        $this->meta = $meta;
+    }
+
+    // }}}
+    // {{{ public function getMeta()
+
+    public function getMeta()
+    {
+        return $this->meta;
     }
 
     // }}}

--- a/src/ResourceStore.php
+++ b/src/ResourceStore.php
@@ -89,6 +89,7 @@ class ResourceStore
 
         $collection = new ResourceCollection($type);
         $collection->setStore($this);
+        $collection->setMeta($body['meta']);
         $collection->decode($body['data']);
 
         foreach ($collection as $resource) {


### PR DESCRIPTION
Previously the ResourceCollection discarded metadata after making a query. This metadata is needed to properly paginate tables displaying these records.

Used for https://hippoeducation.tpondemand.com/entity/1087

Needed to run https://github.com/silverorange/hive/pull/105 